### PR TITLE
Support rook playbooks

### DIFF
--- a/files/scripts/run-rook.sh
+++ b/files/scripts/run-rook.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -e
+
+source /secrets.sh
+
+ENVIRONMENT=${ENVIRONMENT:-rook}
+
+if [[ $# -lt 1 ]]; then
+    echo usage: osism-$ENVIRONMENT SERVICE [...]
+    exit 1
+fi
+
+service=$1
+shift
+
+ANSIBLE_DIRECTORY=/ansible
+CONFIGURATION_DIRECTORY=/opt/configuration
+ENVIRONMENTS_DIRECTORY=$CONFIGURATION_DIRECTORY/environments
+VAULT=${VAULT:-$ENVIRONMENTS_DIRECTORY/.vault_pass}
+
+if [[ -e /ansible/ara.env ]]; then
+    source /ansible/ara.env
+fi
+
+export ANSIBLE_INVENTORY=$ANSIBLE_DIRECTORY/inventory/hosts.yml
+
+export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/ansible.cfg
+if [[ -e /inventory/ansible/ansible.cfg ]]; then
+    export ANSIBLE_CONFIG=/inventory/ansible/ansible.cfg
+elif [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg ]]; then
+    export ANSIBLE_CONFIG=$ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/ansible.cfg
+fi
+
+cd $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT
+
+if [[ -e $ENVIRONMENTS_DIRECTORY/$ENVIRONMENT/playbook-$service.yml ]]; then
+    ansible-playbook \
+      --vault-password-file $VAULT \
+      -e @$ENVIRONMENTS_DIRECTORY/configuration.yml \
+      -e @$ENVIRONMENTS_DIRECTORY/secrets.yml \
+      -e @secrets.yml \
+      -e @images.yml \
+      -e @configuration.yml \
+      "$@" \
+      playbook-$service.yml
+elif [[ -e $ANSIBLE_DIRECTORY/$ENVIRONMENT/$service.yml ]]; then
+    ansible-playbook \
+      --vault-password-file $VAULT \
+      -e @$ENVIRONMENTS_DIRECTORY/configuration.yml \
+      -e @$ENVIRONMENTS_DIRECTORY/secrets.yml \
+      -e @secrets.yml \
+      -e @images.yml \
+      -e @configuration.yml \
+      "$@" \
+      $ANSIBLE_DIRECTORY/$ENVIRONMENT/$service.yml
+else
+    echo "ERROR: service $service in environment $ENVIRONMENT not available"
+    exit 1
+fi

--- a/files/src/render-playbooks.py
+++ b/files/src/render-playbooks.py
@@ -13,6 +13,7 @@ PREFIXES = [
     "manager",
     "monitoring",
     "openstack",
+    "rook",
 ]
 
 KEEP_PREFIX = {
@@ -22,6 +23,7 @@ KEEP_PREFIX = {
     "manager": ["operator", "network"],
     "monitoring": [],
     "openstack": [],
+    "rook": [],
 }
 
 HIDE = {
@@ -31,6 +33,7 @@ HIDE = {
     "manager": [],
     "monitoring": [],
     "openstack": [],
+    "rook": [],
 }
 
 result = {}


### PR DESCRIPTION
With this change it is possible to add playbooks in osism/ansible-playbooks with the prefix rook and these can then be used in the container.