### PR TITLE
Fix black 26.3.1 formatting in kolla_container

### DIFF
--- a/files/plugins/modules/kolla_container.py
+++ b/files/plugins/modules/kolla_container.py
@@ -23,7 +23,6 @@ import traceback
 
 from ansible.module_utils.kolla_container_worker import ContainerWorker
 
-
 DOCUMENTATION = """
 ---
 module: kolla_container


### PR DESCRIPTION
Black 26.3.1 enforces a single blank line between the last import statement and the module-level DOCUMENTATION string constant. The previous formatting with two blank lines now causes a CI linting failure. Remove the extra blank line to comply with the updated formatter.

AI-assisted: Claude Code