### PR TITLE
zuul: increase push job timeout to 2700 s

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -76,6 +76,7 @@
     name: container-image-osism-ansible-build
     pre-run: playbooks/pre.yml
     run: playbooks/build.yml
+    timeout: 2700
     vars:
       docker_namespace: osism
       docker_registry: osism.harbor.regio.digital
@@ -83,6 +84,7 @@
 - job:
     name: abstract-container-image-osism-ansible-push
     abstract: true
+    timeout: 2700
     semaphores:
       - name: semaphore-container-image-osism-ansible-push
     pre-run: playbooks/pre.yml


### PR DESCRIPTION
## Summary

- Adds `timeout: 2700` to `container-image-osism-ansible-build` (check pipeline)
- Adds `timeout: 2700` to `abstract-container-image-osism-ansible-push` (post and periodic-midnight pipelines)
- The abstract push job is the parent for `ansible-collection-commons`, `ansible-collection-services`, `ansible-collection-validations`, `ansible-playbooks`, and `defaults` — those repos are covered via inheritance

## This is a workaround

The root cause is that `ansible-galaxy collection install` — which downloads
~27 Galaxy collections plus 3 GitHub-hosted osism collections — has become
significantly slower, pushing build times close to or past the 1800 s default
timeout. The correct fix is to address the ansible-galaxy download performance
regression; this PR buys time while that is investigated.

Note: `container-image-osism-ansible-build` and `abstract-container-image-osism-ansible-push`
are siblings (both inherit the base job's 1800 s default directly) — they need
separate `timeout` entries.

## Problem

Build times escalated sharply in late April 2026. By early May the nightly
`container-image-osism-ansible-push` job was failing more often than not: **10
TIMED_OUT events in the first 12 days of May** against only 9 successes, with an
average duration of 28 min. The check job (`container-image-osism-ansible-build`)
shows the same pattern: 3 timeouts in April and 1 in the first 12 days of May.

12 months of Zuul build history (2025-05 through 2026-05) show **23 TIMED_OUT
events** for the push jobs across all six repos combined in roughly 660 build
attempts. Timeouts were sparse through most of 2025 and escalated sharply from
April 2026 onward.

## Fix

Increasing the timeout to 2700 s (45 min) prevents builds from failing while the
underlying performance regression is resolved. The higher value still provides a
meaningful safety net against genuinely runaway builds.

## Test plan

- [ ] Verify the check pipeline (`container-image-osism-ansible-build`) completes as SUCCESS
- [ ] Verify the nightly `periodic-midnight` build of `container-image-osism-ansible-push` completes as SUCCESS
- [ ] Close or supersede this PR once the ansible-galaxy performance issue is fixed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)