### PR TITLE
build: drop redundant Python library pins

### DIFF
--- a/files/src/requirements.txt
+++ b/files/src/requirements.txt
@@ -1,7 +1,5 @@
 Jinja2==3.1.6
 PyYAML==6.0.3
-kubernetes==33.1.0
-pottery==3.0.1
 proxmoxer==2.3.0
 python-designateclient==6.4.0
 python-neutronclient==11.8.0

--- a/files/src/templates/requirements.txt.j2
+++ b/files/src/templates/requirements.txt.j2
@@ -14,11 +14,9 @@ ansible-core{{ ansible_core_version }}
 ansible-core=={{ ansible_core_version }}
 {% endif %}
 {% endif %}
-ara=={{ osism_projects['ara'] }}
 asn1crypto==1.5.1
 cryptography==46.0.7
 hvac==2.4.0
-idna==3.11
 osism=={{ osism_projects['osism'] }}
 paramiko==4.0.0
 PyMySQL==1.1.3

--- a/files/src/templates/requirements.txt.j2
+++ b/files/src/templates/requirements.txt.j2
@@ -14,7 +14,6 @@ ansible-core{{ ansible_core_version }}
 ansible-core=={{ ansible_core_version }}
 {% endif %}
 {% endif %}
-asn1crypto==1.5.1
 cryptography==46.0.7
 hvac==2.4.0
 osism=={{ osism_projects['osism'] }}


### PR DESCRIPTION
Remove pins from `files/src/templates/requirements.txt.j2` and
`files/src/requirements.txt` that are already covered by
`python-osism`'s `install_requires`. When a container installs
`osism==X.Y.Z`, all of python-osism's pinned libraries arrive as
hard transitive constraints; re-pinning them here is redundant and
creates Renovate race conditions.

## Changes

**Commit 1 — drop redundant pins:**
- Template: `ara`, `idna`
- Static: `kubernetes`, `pottery`

**Commit 2 — drop `asn1crypto`:**
Image inspection confirmed no runtime consumer: no pip package declares
`Requires-Dist: asn1crypto`; `jc` uses a vendored internal copy
(`jc.parsers.asn1crypto`), not the system package. `community.crypto`
uses the `cryptography` library directly (0 asn1crypto imports across
137 Python files). osism-kubernetes already runs without the system package.

## Test plan

- [ ] `container-image-osism-ansible-build` passes

Related: [ceph-ansible #689](https://github.com/osism/container-image-ceph-ansible/pull/689), [kolla-ansible #906](https://github.com/osism/container-image-kolla-ansible/pull/906), [osism-kubernetes #296](https://github.com/osism/osism-kubernetes/pull/296), [osism/issues#1366](https://github.com/osism/issues/issues/1366)