### PR TITLE
images: wire pinned role images into template

### DIFF
--- a/files/src/templates/images.yml.j2
+++ b/files/src/templates/images.yml.j2
@@ -16,8 +16,14 @@ cgit_image: "{{ '{{' }} docker_registry_cgit {{ '}}' }}/{{ images['cgit'] }}:{{ 
 dnsdist_tag: "{{ versions['dnsdist'] }}"
 dnsdist_image: "{{ '{{' }} docker_registry_dnsdist {{ '}}' }}/{{ images['dnsdist'] }}:{{ '{{' }} dnsdist_tag {{ '}}' }}"
 
+dnsmasq_tag: "{{ versions['dnsmasq'] }}"
+dnsmasq_image: "{{ '{{' }} dnsmasq_docker_registry {{ '}}' }}/{{ images['dnsmasq'] }}:{{ '{{' }} dnsmasq_tag {{ '}}' }}"
+
 docker_openpolicyagent_tag: "{{ versions['docker_openpolicyagent'] }}"
 docker_openpolicyagent_image: "{{ '{{' }} docker_registry_docker_openpolicyagent {{ '}}' }}/{{ images['docker_openpolicyagent'] }}:{{ '{{' }} docker_openpolicyagent_tag {{ '}}' }}"
+
+gnmic_tag: "{{ versions['gnmic'] }}"
+gnmic_image: "{{ '{{' }} gnmic_docker_registry {{ '}}' }}/{{ images['gnmic'] }}:{{ '{{' }} gnmic_tag {{ '}}' }}"
 
 homer_tag: "{{ versions['homer'] }}"
 homer_image: "{{ '{{' }} docker_registry_homer {{ '}}' }}/{{ images['homer'] }}:{{ '{{' }} homer_tag {{ '}}' }}"
@@ -49,6 +55,9 @@ osism_image: "{{ '{{' }} docker_registry_ansible {{ '}}' }}/{{ images['osism'] }
 patchman_tag: "{{ versions['patchman'] }}"
 patchman_image: "{{ '{{' }} docker_registry_patchman {{ '}}' }}/{{ images['patchman'] }}:{{ '{{' }} patchman_tag {{ '}}' }}"
 
+pgautoupgrade_tag: "{{ versions['pgautoupgrade'] }}"
+pgautoupgrade_image: "{{ '{{' }} docker_registry_pgautoupgrade {{ '}}' }}/{{ images['pgautoupgrade'] }}:{{ '{{' }} pgautoupgrade_tag {{ '}}' }}"
+
 phpmyadmin_tag: "{{ versions['phpmyadmin'] }}"
 phpmyadmin_image: "{{ '{{' }} docker_registry {{ '}}' }}/{{ images['phpmyadmin'] }}:{{ '{{' }} phpmyadmin_tag {{ '}}' }}"
 
@@ -67,8 +76,14 @@ openstack_database_exporter_image: "{{ '{{' }} docker_openstack_database_exporte
 registry_tag: "{{ versions['registry'] }}"
 registry_image: "{{ '{{' }} docker_registry {{ '}}' }}/{{ images['registry'] }}:{{ '{{' }} registry_tag {{ '}}' }}"
 
+scaphandre_tag: "{{ versions['scaphandre'] }}"
+scaphandre_image: "{{ '{{' }} docker_registry_scaphandre {{ '}}' }}/{{ images['scaphandre'] }}:{{ '{{' }} scaphandre_tag {{ '}}' }}"
+
 squid_tag: "{{ versions['squid'] }}"
 squid_image: "{{ '{{' }} docker_registry {{ '}}' }}/{{ images['squid'] }}:{{ '{{' }} squid_tag {{ '}}' }}"
+
+stepca_tag: "{{ versions['stepca'] }}"
+stepca_image: "{{ '{{' }} docker_registry_stepca {{ '}}' }}/{{ images['stepca'] }}:{{ '{{' }} stepca_tag {{ '}}' }}"
 
 traefik_tag: "{{ versions['traefik'] }}"
 traefik_image: "{{ '{{' }} docker_registry_traefik {{ '}}' }}/{{ images['traefik'] }}:{{ '{{' }} traefik_tag {{ '}}' }}"

--- a/files/src/templates/images.yml.j2
+++ b/files/src/templates/images.yml.j2
@@ -49,6 +49,9 @@ nginx_image: "{{ '{{' }} docker_registry {{ '}}' }}/{{ images['nginx'] }}:{{ '{{
 openstack_health_monitor_tag: "{{ versions['openstack_health_monitor'] }}"
 openstack_health_monitor_image: "{{ '{{' }} docker_registry_openstack_health_monitor {{ '}}' }}/{{ images['openstack_health_monitor'] }}:{{ '{{' }} openstack_health_monitor_tag {{ '}}' }}"
 
+opentelemetry_collector_tag: "{{ versions['opentelemetry_collector'] }}"
+opentelemetry_collector_image: "{{ '{{' }} docker_registry_opentelemetry_collector {{ '}}' }}/{{ images['opentelemetry_collector'] }}:{{ '{{' }} opentelemetry_collector_tag {{ '}}' }}"
+
 osism_tag: "{{ versions['osism'] }}"
 osism_image: "{{ '{{' }} docker_registry_ansible {{ '}}' }}/{{ images['osism'] }}:{{ '{{' }} osism_tag {{ '}}' }}"
 


### PR DESCRIPTION
Wire the Class-A service images into the manager render template so their maintained `osism/release` `base.yml` pins govern the deployed version, per `osism/issues#1397`.

Each is structurally identical to an already-wired image (`base.yml` + `etc/images.yml` entries present) — only the static render-template line was missing, so the role default deployed and had drifted behind the release pin. Adding the tag+image lines makes the rendered `group_vars/all/images.yml` override the role default. Each `_image` line reproduces the role's own construction (its actual registry variable + `etc/images.yml` path), so only the tag changes.

**Direct-pin images** (`8552718`): `dnsmasq` (2.90→2.91), `gnmic`, `pgautoupgrade`, `scaphandre` (1.0.0→1.0.2), `stepca` (0.28.4→0.30.2).

**Indirected image** (`f395ac5`): `opentelemetry_collector` (0.136.0→0.155.0). Committed separately because it surfaced later — its role default indirects the tag through a `_version` var (`opentelemetry_collector_tag: "{{ opentelemetry_collector_version }}"`), so the role-pin drift scan only resolved it after the `_tag → _version` parser fix; it was not visible when the direct-pin batch was written.

Verified: the drift detector reclassifies all six from `role_shadows` LIVE to DORMANT (**0 LIVE remaining**).

Part of osism/issues#1397.