### PR TITLE
images: wire substation

### DIFF
--- a/files/src/templates/images.yml.j2
+++ b/files/src/templates/images.yml.j2
@@ -88,6 +88,9 @@ squid_image: "{{ '{{' }} docker_registry {{ '}}' }}/{{ images['squid'] }}:{{ '{{
 stepca_tag: "{{ versions['stepca'] }}"
 stepca_image: "{{ '{{' }} docker_registry_stepca {{ '}}' }}/{{ images['stepca'] }}:{{ '{{' }} stepca_tag {{ '}}' }}"
 
+substation_tag: "{{ versions['substation'] }}"
+substation_image: "{{ '{{' }} docker_registry_substation {{ '}}' }}/{{ images['substation'] }}:{{ '{{' }} substation_tag {{ '}}' }}"
+
 traefik_tag: "{{ versions['traefik'] }}"
 traefik_image: "{{ '{{' }} docker_registry_traefik {{ '}}' }}/{{ images['traefik'] }}:{{ '{{' }} traefik_tag {{ '}}' }}"
 


### PR DESCRIPTION
Wire `substation` into the manager render template so the release `base.yml`
pin governs the deployed tag instead of the role default (`latest`).

Adds `substation_tag`/`substation_image` to `images.yml.j2`; the rendered
`group_vars/all/images.yml` then overrides the role default at deploy. The
image line uses the substation-specific registry var `docker_registry_substation`
(ghcr.io) and the mirror-map path, so only the tag source changes.

### Consistency

Both the `_tag` and `_image` lines are included, matching the template: all 45
existing entries carry both — there are no tag-only entries. The per-image
registry var (`docker_registry_substation`) is also the norm (~30 images use a
`docker_registry_<name>`; only 12 use the plain mirror default), and it is
exactly what keeps the ghcr.io image off the mirror default. This supersedes the
tag-only suggestion in osism/issues#1404 (step 3): tag-only would make substation
the sole inconsistent entry, and its stated concern (wrong registry default) does
not apply here.

### Related

- osism/issues#1404