### PR TITLE
hardening: create privsep dir before validate

### DIFF
--- a/patches/hardening/sshd-privsep-dir-before-validate.patch
+++ b/patches/hardening/sshd-privsep-dir-before-validate.patch
@@ -1,0 +1,51 @@
+--- a/tasks/rhel7stig/sshd.yml
++++ b/tasks/rhel7stig/sshd.yml
+@@ -13,6 +13,48 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
++# `sshd -T` does not only parse the candidate file: it also checks that the
++# privilege separation directory exists, exiting 255 with "Missing privilege
++# separation directory" when it does not. That directory is the RuntimeDirectory
++# of the sshd unit, so it is absent whenever the service is not running -- and on
++# a socket-activated host (Ubuntu 24.04 ships ssh.socket enabled and ssh.service
++# disabled) the service is legitimately stopped much of the time, including right
++# after an openssh-server upgrade whose postinst stops it. The host stays fully
++# reachable through the socket, so nothing is wrong -- yet the two tasks below
++# fail, for reasons that have nothing to do with the configuration being
++# validated. Create the directory first so the validation depends on the file
++# alone. Same tag set as those tasks, so no tag selection can run a validation
++# without this prerequisite. Override security_sshd_privsep_dir for a platform
++# using a different path.
++- name: Ensure the sshd privilege separation directory exists
++  file:
++    path: "{{ security_sshd_privsep_dir | default('/var/empty/sshd' if ansible_facts['os_family'] == 'RedHat' else '/run/sshd') }}"
++    state: directory
++    owner: root
++    group: root
++    mode: "0755"
++  tags:
++    - high
++    - sshd
++    - V-71939
++    - V-71957
++    - V-71959
++    - V-72221
++    - V-72225
++    - V-72237
++    - V-72241
++    - V-72243
++    - V-72245
++    - V-72247
++    - V-72249
++    - V-72251
++    - V-72253
++    - V-72261
++    - V-72263
++    - V-72265
++    - V-72267
++    - V-72303
++
+ - name: Drop options from SSH config that we manage
+   lineinfile:
+     path: /etc/ssh/sshd_config


### PR DESCRIPTION
The hardening role validates its `sshd_config` edits with
`validate: /usr/sbin/sshd -T -f %s`. `sshd -T` does not only parse the candidate
file: it also checks that the privilege separation directory exists, exiting 255
with `Missing privilege separation directory` when it does not. That directory is
`ssh.service`'s systemd `RuntimeDirectory`, so it is absent whenever the service
is stopped — which couples validating a config *file* to live service state.

On Ubuntu 24.04 that coupling bites, because `ssh.socket` is enabled and
`ssh.service` disabled. The service is then legitimately stopped much of the time,
including right after an `openssh-server` upgrade, whose postinst stops it and
leaves reachability to the socket. The host is fine — it keeps listening on `:22`,
and the next inbound connection starts the daemon again and recreates the
directory — but until that happens both `sshd_config` tasks in this role fail for a
reason that has nothing to do with the configuration they are validating. Ansible
reusing a multiplexed connection widens the window, because no new connection
arrives to trigger socket activation.

Measured on a live Ubuntu 24.04 host:

| step | `ssh.service` | `/run/sshd` | `sshd -T` |
|---|---|---|---|
| baseline | active | present | rc 0 |
| after `apt-get install --reinstall openssh-server` | inactive | gone | **rc 255** |
| after `mkdir -p /run/sshd` | inactive | present | rc 0 |
| after one TCP connect to `:22` | active | present | rc 0 |

`:22` kept listening throughout, so the host never became unreachable. `sshd -t`,
`sshd -T` and `sshd -t -q` all exit 255, so no flag avoids the check — creating the
directory is the only fix available to the role.

### Why it is hard to reproduce

The condition is **self-healing**: any new TCP connection to `:22` triggers socket
activation, starts the daemon and recreates the directory — even a connection that
fails authentication. So the obvious way to investigate, logging in to look at the
host, destroys the evidence on arrival.

Reproducing it needs all three of:

- `ssh.socket` enabled and `ssh.service` disabled, so the postinst leaves the
  service stopped instead of running (the Ubuntu 24.04 default);
- the `openssh-server` upgrade applied **by the ansible run itself**, not earlier.
  A host that was already up to date — or where `unattended-upgrades` got there
  first, before ansible connected — never loses the directory while ansible is
  working on it;
- ansible **reusing a multiplexed connection** (`ControlPersist`), so that no new
  connection intervenes between the upgrade and the validating tasks. Without
  multiplexing every task opens a fresh connection, which heals the state before
  the validation runs, and such a deployment never sees this at all.

That combination is also why it looks host-specific and intermittent while being
deterministic. In the CI build linked below, `Upgrade packages` reported `changed`
on exactly the two of six nodes that then failed, and those same two failed again
nine minutes later in the same build — both times inside the 1800 s mux window,
while the other five were never affected.

### The patch

Creates the directory ahead of the two validating tasks, so validation depends on
the file alone. It carries the same tag set as the tasks it protects, so no
`--tags` selection can run a validation without the prerequisite, and
`security_sshd_privsep_dir` can be overridden where a platform uses a different
path (`/var/empty/sshd` on RedHat).

### Two constraints worth knowing during review

It is written against the role revision the release pins
(`ansible_roles.hardening`, `e77c311`), not upstream `master`; an earlier draft
written against `master` applied only with fuzz.

The filename sorts **after** `do-not-copy-login-warning-banner.patch`
deliberately. Both patches edit `tasks/rhel7stig/sshd.yml`, and inserting these
tasks earlier in the file destroys the context that patch depends on. `patch` then
reports `Reversed (or previously applied) patch detected!`, the
`patch --dry-run … || exit 1` gate fails the image build, and the misleading
message invites deleting a patch that is still required — dropping it would start
overwriting `/etc/motd` with the STIG banner.

### Verification

- Image builds with `VERSION=v0.20260615.0`; all four `patches/hardening/*.patch`
  apply in glob order.
- `osism apply hardening` on a live Ubuntu 24.04 node: `ok=76 changed=17 failed=0`,
  idempotent on re-run, and the `restart ssh` handler fired without stranding the
  host.

- osism/issues#1345
- Hit in CI on `testbed-upgrade-stable-ubuntu-24.04` (periodic-midnight), build
  [77582294](https://logs.services.osism.tech/775/osism/77582294ffd34c0ba15553fc992c7e7c/):
  `testbed-node-0` and `testbed-node-2`, failing at 05:16:38 and again at 05:24:10.
